### PR TITLE
Update Description field in DESCRIPTION file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,11 +6,15 @@ Authors@R: c(
     person("Beesley", "Tom", , "t.beesley@lancaster.ac.uk", role = c("aut", "cre")),
     person("Ivory", "Matthew", , "matthew.ivory@lancaster.ac.uk", role = "aut")
   )
-Description: Enables the automation of actions across the pipeline starting from combining raw binocular data, repairing missing data, 
-  through to event-related processing (fixations, saccades, time in AOIs), to data visualisation. These tools take relatively raw (trial, time, x, and y form) data 
-  and can be used to return fixations, saccades, and AOI entries and time spent in AOIs. 
-  As the tools rely on this basic data format, the functions can work with data from any eye tracking device. 
-  Implements fixation and saccade detection using methods proposed by Salvucci and Goldberg (2000) <doi:10.1145/355017.355028>
+Description: Enables the automation of actions across the pipeline starting
+    from combining raw binocular data, repairing missing data, through to
+    event-related processing (fixations, saccades, time in AOIs), to data
+    visualisation. These tools take relatively raw (trial, time, x, and y
+    form) data and can be used to return fixations, saccades, and AOI entries
+    and time spent in AOIs. As the tools rely on this basic data format, the
+    functions can work with data from any eye tracking device. Implements
+    fixation and saccade detection using methods proposed by Salvucci and
+    Goldberg (2000) <doi:10.1145/355017.355028>
 License: GPL-3
 URL: https://tombeesley.github.io/eyetools/
 BugReports: https://github.com/tombeesley/eyetools/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Description: Enables the automation of actions across the pipeline starting
     and time spent in AOIs. As the tools rely on this basic data format, the
     functions can work with data from any eye tracking device. Implements
     fixation and saccade detection using methods proposed by Salvucci and
-    Goldberg (2000) <doi:10.1145/355017.355028>
+    Goldberg (2000) <doi:10.1145/355017.355028>.
 License: GPL-3
 URL: https://tombeesley.github.io/eyetools/
 BugReports: https://github.com/tombeesley/eyetools/issues


### PR DESCRIPTION
Checking the package with `devtools::check()` issues a warning about the Description field of the DESCRIPTION file. This change addresses the warning by:

- indenting by the suggested 4 spaces rather than 2
- re-wrapping the paragraph to be less than 80 characters per line
- terminating the paragraph with a full stop

<https://r-pkgs.org/description.html#sec-description-title-and-description>